### PR TITLE
Add support for Minecraft 26.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Sentinel NPCs: Combat NPCs for Spigot!
 
 ![AnimatedSentinel](https://i.imgur.com/VDwTzrs.gif)
 
-**Version 2.9.2**: Compatible with Spigot 1.19+ through 1.21.3 (Primarily targeted at 1.21.3 - see 'Common Issues' section below if on older supported versions).
+**Version 2.9.3**: Compatible with Spigot 1.19+ through 26.1 (Primarily targeted at 26.1 - see 'Common Issues' section below if on older supported versions).
 Contains unvalidated backsupport for older Minecraft versions.
 
 ### Downloads
@@ -346,7 +346,7 @@ If you're building a separate plugin you would like to integrate into Sentinel, 
         <dependency>
             <groupId>org.mcmonkey</groupId>
             <artifactId>sentinel</artifactId>
-            <version>2.9.2-SNAPSHOT</version>
+            <version>2.9.3-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
             <exclusions>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Sentinel NPCs: Combat NPCs for Spigot!
 
 ![AnimatedSentinel](https://i.imgur.com/VDwTzrs.gif)
 
-**Version 2.9.3**: Compatible with Spigot 1.19+ through 26.1 (Primarily targeted at 26.1 - see 'Common Issues' section below if on older supported versions).
+**Version 2.9.4**: Compatible with Spigot 1.19+ through 26.1 (Primarily targeted at 26.1 - see 'Common Issues' section below if on older supported versions).
 Contains unvalidated backsupport for older Minecraft versions.
 
 ### Downloads
@@ -346,7 +346,7 @@ If you're building a separate plugin you would like to integrate into Sentinel, 
         <dependency>
             <groupId>org.mcmonkey</groupId>
             <artifactId>sentinel</artifactId>
-            <version>2.9.3-SNAPSHOT</version>
+            <version>2.9.4-SNAPSHOT</version>
             <type>jar</type>
             <scope>provided</scope>
             <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <bukkit.version>1.21.11-R0.2-SNAPSHOT</bukkit.version>
-        <citizens.version>2.0.41-SNAPSHOT</citizens.version>
+        <bukkit.version>26.1.2-R0.1-SNAPSHOT</bukkit.version>
+        <citizens.version>2.0.42-SNAPSHOT</citizens.version>
         <BUILD_NUMBER>Unknown</BUILD_NUMBER>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.mcmonkey</groupId>
     <artifactId>sentinel</artifactId>
     <packaging>jar</packaging>
-    <version>2.9.3-SNAPSHOT</version>
+    <version>2.9.4-SNAPSHOT</version>
     <name>Sentinel</name>
     <description>Combat NPCs for Spigot</description>
 

--- a/src/main/java/org/mcmonkey/sentinel/utilities/SentinelNMSHelper.java
+++ b/src/main/java/org/mcmonkey/sentinel/utilities/SentinelNMSHelper.java
@@ -31,7 +31,7 @@ public class SentinelNMSHelper {
     /**
      * Returns the first of the given class names that exists (multi-mapping support: Mojang-mapped vs legacy Spigot-remapped NMS).
      */
-    private static Class<?> classForFirst(String... classNames) throws ClassNotFoundException {
+    private static Class<?> classForFirst(String... classNames) {
         for (String name : classNames) {
             try {
                 return Class.forName(name);
@@ -40,7 +40,7 @@ public class SentinelNMSHelper {
                 // Try the next candidate name.
             }
         }
-        throw new ClassNotFoundException("None of the candidate NMS classes exist: " + String.join(", ", classNames));
+        throw new RuntimeException("None of the candidate NMS classes exist: " + String.join(", ", classNames));
     }
 
     /**
@@ -48,12 +48,12 @@ public class SentinelNMSHelper {
      */
     private static MethodHandle methodHandleForFirst(Class<?> clazz, Class<?>[] params, String... methodNames) {
         for (String name : methodNames) {
-            MethodHandle handle = NMS.getMethodHandle(clazz, name, false, params); // log=false: missing candidates are expected, don't spam the console
+            MethodHandle handle = NMS.getMethodHandle(clazz, name, false, params);
             if (handle != null) {
                 return handle;
             }
         }
-        return null;
+        throw new RuntimeException("None of the candidate NMS methods exist: " + String.join(", ", methodNames));
     }
 
     public static void init() {
@@ -74,7 +74,6 @@ public class SentinelNMSHelper {
             String broadcastEffectMethod = "broadcastEntityEffect", dataWatcherSet = "set";
             if (SentinelVersionCompat.v1_17) { // 1.17+ - Mojang mappings update
                 nmsEntity = Class.forName("net.minecraft.world.entity.Entity");
-                // Try Mojang-mapped names first (server runtime mappings since 1.20.5+, including 26.1), then the legacy Spigot-remapped names (1.17-1.21).
                 nmsWorld = classForFirst("net.minecraft.world.level.Level", "net.minecraft.world.level.World");
                 nmsDataWatcher = classForFirst("net.minecraft.network.syncher.SynchedEntityData", "net.minecraft.network.syncher.DataWatcher");
                 nmsDataWatcherObject = classForFirst("net.minecraft.network.syncher.EntityDataAccessor", "net.minecraft.network.syncher.DataWatcherObject");
@@ -108,12 +107,8 @@ public class SentinelNMSHelper {
             }
             NMSENTITY_WORLDGETTER = NMS.getFirstGetter(nmsEntity, nmsWorld);
             NMSENTITY_GETDATAWATCHER = NMS.getFirstGetter(nmsEntity, nmsDataWatcher);
-            // Try the Mojang-mapped method name first (26.1+ runs on Mojang mappings), then fall back to the per-version Spigot/obfuscated name selected above.
             NMSWORLD_BROADCASTENTITYEFFECT = methodHandleForFirst(nmsWorld, new Class<?>[]{nmsEntity, byte.class}, "broadcastEntityEvent", broadcastEffectMethod);
             DATWATCHER_SET = methodHandleForFirst(nmsDataWatcher, new Class<?>[]{nmsDataWatcherObject, Object.class}, "set", dataWatcherSet);
-            if (NMSWORLD_BROADCASTENTITYEFFECT == null || DATWATCHER_SET == null) {
-                nmsWorks = false; // Couldn't resolve the NMS methods on this version; cosmetic NMS effects will be skipped (plugin otherwise functions normally).
-            }
         }
         catch (Throwable ex) {
             ex.printStackTrace();

--- a/src/main/java/org/mcmonkey/sentinel/utilities/SentinelNMSHelper.java
+++ b/src/main/java/org/mcmonkey/sentinel/utilities/SentinelNMSHelper.java
@@ -117,7 +117,7 @@ public class SentinelNMSHelper {
         }
         catch (Throwable ex) {
             ex.printStackTrace();
-            nmsWorks = false; 
+            nmsWorks = false;
         }
     }
 

--- a/src/main/java/org/mcmonkey/sentinel/utilities/SentinelNMSHelper.java
+++ b/src/main/java/org/mcmonkey/sentinel/utilities/SentinelNMSHelper.java
@@ -7,7 +7,6 @@ import org.bukkit.entity.IronGolem;
 import org.bukkit.event.inventory.InventoryEvent;
 
 import java.lang.invoke.MethodHandle;
-import java.lang.reflect.Field;
 
 /**
  * Helper for NMS-based actions.
@@ -29,6 +28,34 @@ public class SentinelNMSHelper {
         }
     }
 
+    /**
+     * Returns the first of the given class names that exists (multi-mapping support: Mojang-mapped vs legacy Spigot-remapped NMS).
+     */
+    private static Class<?> classForFirst(String... classNames) throws ClassNotFoundException {
+        for (String name : classNames) {
+            try {
+                return Class.forName(name);
+            }
+            catch (ClassNotFoundException ex) {
+                // Try the next candidate name.
+            }
+        }
+        throw new ClassNotFoundException("None of the candidate NMS classes exist: " + String.join(", ", classNames));
+    }
+
+    /**
+     * Returns a handle for the first of the given method names that exists on the class (multi-mapping support: Mojang names vs obfuscated/Spigot names).
+     */
+    private static MethodHandle methodHandleForFirst(Class<?> clazz, Class<?>[] params, String... methodNames) {
+        for (String name : methodNames) {
+            MethodHandle handle = NMS.getMethodHandle(clazz, name, false, params); // log=false: missing candidates are expected, don't spam the console
+            if (handle != null) {
+                return handle;
+            }
+        }
+        return null;
+    }
+
     public static void init() {
         try {
             if (SentinelVersionCompat.v1_10) {
@@ -47,9 +74,10 @@ public class SentinelNMSHelper {
             String broadcastEffectMethod = "broadcastEntityEffect", dataWatcherSet = "set";
             if (SentinelVersionCompat.v1_17) { // 1.17+ - Mojang mappings update
                 nmsEntity = Class.forName("net.minecraft.world.entity.Entity");
-                nmsWorld = Class.forName("net.minecraft.world.level.World"); // Level
-                nmsDataWatcher = Class.forName("net.minecraft.network.syncher.DataWatcher"); // SynchedEntityData
-                nmsDataWatcherObject = Class.forName("net.minecraft.network.syncher.DataWatcherObject"); // EntityDataAccessor
+                // Try Mojang-mapped names first (server runtime mappings since 1.20.5+, including 26.1), then the legacy Spigot-remapped names (1.17-1.21).
+                nmsWorld = classForFirst("net.minecraft.world.level.Level", "net.minecraft.world.level.World");
+                nmsDataWatcher = classForFirst("net.minecraft.network.syncher.SynchedEntityData", "net.minecraft.network.syncher.DataWatcher");
+                nmsDataWatcherObject = classForFirst("net.minecraft.network.syncher.EntityDataAccessor", "net.minecraft.network.syncher.DataWatcherObject");
                 if (SentinelVersionCompat.v1_21 && !SentinelVersionCompat.vFuture) { // 1.21 names
                     broadcastEffectMethod = "a"; // net.minecraft.world.level.Level#broadcastEntityEvent(Entity,byte)
                     dataWatcherSet = "a"; // net.minecraft.network.syncher.SynchedEntityData#set
@@ -80,8 +108,12 @@ public class SentinelNMSHelper {
             }
             NMSENTITY_WORLDGETTER = NMS.getFirstGetter(nmsEntity, nmsWorld);
             NMSENTITY_GETDATAWATCHER = NMS.getFirstGetter(nmsEntity, nmsDataWatcher);
-            NMSWORLD_BROADCASTENTITYEFFECT = NMS.getMethodHandle(nmsWorld, broadcastEffectMethod, true, nmsEntity, byte.class);
-            DATWATCHER_SET = NMS.getMethodHandle(nmsDataWatcher, dataWatcherSet, true, nmsDataWatcherObject, Object.class);
+            // Try the Mojang-mapped method name first (26.1+ runs on Mojang mappings), then fall back to the per-version Spigot/obfuscated name selected above.
+            NMSWORLD_BROADCASTENTITYEFFECT = methodHandleForFirst(nmsWorld, new Class<?>[]{nmsEntity, byte.class}, "broadcastEntityEvent", broadcastEffectMethod);
+            DATWATCHER_SET = methodHandleForFirst(nmsDataWatcher, new Class<?>[]{nmsDataWatcherObject, Object.class}, "set", dataWatcherSet);
+            if (NMSWORLD_BROADCASTENTITYEFFECT == null || DATWATCHER_SET == null) {
+                nmsWorks = false; // Couldn't resolve the NMS methods on this version; cosmetic NMS effects will be skipped (plugin otherwise functions normally).
+            }
         }
         catch (Throwable ex) {
             ex.printStackTrace();

--- a/src/main/java/org/mcmonkey/sentinel/utilities/SentinelVersionCompat.java
+++ b/src/main/java/org/mcmonkey/sentinel/utilities/SentinelVersionCompat.java
@@ -52,19 +52,9 @@ public class SentinelVersionCompat {
     public static final boolean v1_8, v1_9, v1_10, v1_11, v1_12, v1_13, v1_14, v1_15, v1_16, v1_17, v1_18, v1_19, v1_20, v1_21, v26_1, vFuture;
 
     static {
-        String vers = Bukkit.getBukkitVersion(); // Returns in format like: 1.12.2-R0.1-SNAPSHOT (or 26.1.2-R0.1-SNAPSHOT for the post-1.x version scheme)
-        // Minecraft moved from the "1.x" scheme to a year-based one (e.g. 26.1.2 = year 26, major release 1, patch 2). Parse the leading "major.minor".
-        int versMajor = 1, versMinor = 0;
-        try {
-            String[] parts = vers.split("[.\\-]");
-            versMajor = Integer.parseInt(parts[0]);
-            versMinor = Integer.parseInt(parts[1]);
-        } catch (NumberFormatException | ArrayIndexOutOfBoundsException ex) {
-            // Leave as 1.0 (legacy "1.x" scheme); the startsWith checks below handle minor versions.
-        }
-        // Anything past the latest known release (26.1) is treated as future.
-        vFuture = versMajor > 26 || (versMajor == 26 && versMinor > 1);
-        v26_1 = (versMajor == 26 && versMinor >= 1) || vFuture;
+        String vers = Bukkit.getBukkitVersion(); // Returns in format like: 1.12.2-R0.1-SNAPSHOT
+        vFuture = vers.startsWith("26.") || vers.startsWith("27.") || vers.startsWith("28.") || vers.startsWith("29.");
+        v26_1 = vers.startsWith("26.1") || vFuture;
         v1_21 = vers.startsWith("1.21") || v26_1;
         v1_20 = vers.startsWith("1.20") || v1_21;
         v1_19 = vers.startsWith("1.19") || v1_20;
@@ -217,7 +207,8 @@ public class SentinelVersionCompat {
             SentinelTarget.MOBS = new SentinelTarget(combine(v1_19_passive(), v1_19_monsters()), "MOB");
             SentinelTarget.MONSTERS = new SentinelTarget(v1_19_monsters(), "MONSTER");
         }
-        if (v1_21) { // BREEZE/BOGGED/ARMADILLO added in 1.21, still present in newer versions
+        // TODO: The below section is entirely wrong and needs redoing properly
+        if (v1_21) {
             SentinelTarget.HOGLINS = new SentinelTarget(new EntityType[]{EntityType.BREEZE}, "BREEZE");
             SentinelTarget.HOGLINS = new SentinelTarget(new EntityType[]{EntityType.BOGGED}, "BOGGED", "BOGGEDSKELETON", "BOGGED_SKELETON");
             SentinelTarget.HOGLINS = new SentinelTarget(new EntityType[]{EntityType.ARMADILLO}, "ARMADILLO");
@@ -227,7 +218,7 @@ public class SentinelVersionCompat {
             SentinelTarget.MOBS = new SentinelTarget(combine(v1_19_passive(), v1_19_monsters()), "MOB");
             SentinelTarget.MONSTERS = new SentinelTarget(v1_19_monsters(), "MONSTER");
         }
-        if (v26_1) { // && !future ; 26.1 "Tiny Takeover" added no new mobs (only baby variants of existing mobs), so reuse the latest known lists
+        if (v26_1) { // && !v26_2 or v27
             SentinelTarget.PASSIVE_MOBS = new SentinelTarget(v1_19_passive(), passiveNames());
             SentinelTarget.MOBS = new SentinelTarget(combine(v1_19_passive(), v1_19_monsters()), "MOB");
             SentinelTarget.MONSTERS = new SentinelTarget(v1_19_monsters(), "MONSTER");

--- a/src/main/java/org/mcmonkey/sentinel/utilities/SentinelVersionCompat.java
+++ b/src/main/java/org/mcmonkey/sentinel/utilities/SentinelVersionCompat.java
@@ -53,7 +53,8 @@ public class SentinelVersionCompat {
 
     static {
         String vers = Bukkit.getBukkitVersion(); // Returns in format like: 1.12.2-R0.1-SNAPSHOT
-        vFuture = vers.startsWith("26.") || vers.startsWith("27.") || vers.startsWith("28.") || vers.startsWith("29.");
+        vFuture = vers.startsWith("26.2") || vers.startsWith("26.3") || vers.startsWith("26.4")
+                || vers.startsWith("27.") || vers.startsWith("28.") || vers.startsWith("29.");
         v26_1 = vers.startsWith("26.1") || vFuture;
         v1_21 = vers.startsWith("1.21") || v26_1;
         v1_20 = vers.startsWith("1.20") || v1_21;
@@ -207,21 +208,15 @@ public class SentinelVersionCompat {
             SentinelTarget.MOBS = new SentinelTarget(combine(v1_19_passive(), v1_19_monsters()), "MOB");
             SentinelTarget.MONSTERS = new SentinelTarget(v1_19_monsters(), "MONSTER");
         }
-        // TODO: The below section is entirely wrong and needs redoing properly
         if (v1_21) {
-            SentinelTarget.HOGLINS = new SentinelTarget(new EntityType[]{EntityType.BREEZE}, "BREEZE");
-            SentinelTarget.HOGLINS = new SentinelTarget(new EntityType[]{EntityType.BOGGED}, "BOGGED", "BOGGEDSKELETON", "BOGGED_SKELETON");
-            SentinelTarget.HOGLINS = new SentinelTarget(new EntityType[]{EntityType.ARMADILLO}, "ARMADILLO");
+            SentinelTarget.BREEZES = new SentinelTarget(new EntityType[]{EntityType.BREEZE}, "BREEZE");
+            SentinelTarget.BOGGEDS = new SentinelTarget(new EntityType[]{EntityType.BOGGED}, "BOGGED", "BOGGEDSKELETON", "BOGGED_SKELETON");
+            SentinelTarget.ARMADILLOS = new SentinelTarget(new EntityType[]{EntityType.ARMADILLO}, "ARMADILLO");
         }
-        if (v1_21 && !v26_1) {
-            SentinelTarget.PASSIVE_MOBS = new SentinelTarget(v1_19_passive(), passiveNames());
-            SentinelTarget.MOBS = new SentinelTarget(combine(v1_19_passive(), v1_19_monsters()), "MOB");
-            SentinelTarget.MONSTERS = new SentinelTarget(v1_19_monsters(), "MONSTER");
-        }
-        if (v26_1) { // && !v26_2 or v27
-            SentinelTarget.PASSIVE_MOBS = new SentinelTarget(v1_19_passive(), passiveNames());
-            SentinelTarget.MOBS = new SentinelTarget(combine(v1_19_passive(), v1_19_monsters()), "MOB");
-            SentinelTarget.MONSTERS = new SentinelTarget(v1_19_monsters(), "MONSTER");
+        if (v1_21) { // && !v1_22
+            SentinelTarget.PASSIVE_MOBS = new SentinelTarget(v1_21_passive(), passiveNames());
+            SentinelTarget.MOBS = new SentinelTarget(combine(v1_21_passive(), v1_21_monsters()), "MOB");
+            SentinelTarget.MONSTERS = new SentinelTarget(v1_21_monsters(), "MONSTER");
         }
         // ========================== End Entities ==========================
         // ========================== Begin Materials ==========================
@@ -490,6 +485,10 @@ public class SentinelVersionCompat {
         return res;
     }
 
+    static EntityType[] v1_21_passive() {
+        return combine(v1_19_passive(), EntityType.ARMADILLO);
+    }
+
     static EntityType[] v1_8_monsters() {
         return new EntityType[]{EntityType.GUARDIAN, EntityType.CREEPER, EntityType.SKELETON, EntityType.ZOMBIE,
                 EntityType.MAGMA_CUBE, EntityType.valueOf("PIG_ZOMBIE"), EntityType.SILVERFISH, EntityType.BAT, EntityType.BLAZE,
@@ -551,6 +550,10 @@ public class SentinelVersionCompat {
 
     static EntityType[] v1_19_monsters() {
         return combine(v1_16_monsters(), EntityType.WARDEN);
+    }
+
+    static EntityType[] v1_21_monsters() {
+        return combine(v1_16_monsters(), EntityType.BREEZE, EntityType.BOGGED);
     }
 
     /**

--- a/src/main/java/org/mcmonkey/sentinel/utilities/SentinelVersionCompat.java
+++ b/src/main/java/org/mcmonkey/sentinel/utilities/SentinelVersionCompat.java
@@ -49,12 +49,23 @@ public class SentinelVersionCompat {
     /**
      * Boolean indicating if the server version is >= the named version.
      */
-    public static final boolean v1_8, v1_9, v1_10, v1_11, v1_12, v1_13, v1_14, v1_15, v1_16, v1_17, v1_18, v1_19, v1_20, v1_21, vFuture;
+    public static final boolean v1_8, v1_9, v1_10, v1_11, v1_12, v1_13, v1_14, v1_15, v1_16, v1_17, v1_18, v1_19, v1_20, v1_21, v26_1, vFuture;
 
     static {
-        String vers = Bukkit.getBukkitVersion(); // Returns in format like: 1.12.2-R0.1-SNAPSHOT
-        vFuture = vers.startsWith("1.22") || vers.startsWith("1.23") || vers.startsWith("1.24") || vers.startsWith("1.25") || vers.startsWith("1.26");
-        v1_21 = vers.startsWith("1.21") || vFuture;
+        String vers = Bukkit.getBukkitVersion(); // Returns in format like: 1.12.2-R0.1-SNAPSHOT (or 26.1.2-R0.1-SNAPSHOT for the post-1.x version scheme)
+        // Minecraft moved from the "1.x" scheme to a year-based one (e.g. 26.1.2 = year 26, major release 1, patch 2). Parse the leading "major.minor".
+        int versMajor = 1, versMinor = 0;
+        try {
+            String[] parts = vers.split("[.\\-]");
+            versMajor = Integer.parseInt(parts[0]);
+            versMinor = Integer.parseInt(parts[1]);
+        } catch (NumberFormatException | ArrayIndexOutOfBoundsException ex) {
+            // Leave as 1.0 (legacy "1.x" scheme); the startsWith checks below handle minor versions.
+        }
+        // Anything past the latest known release (26.1) is treated as future.
+        vFuture = versMajor > 26 || (versMajor == 26 && versMinor > 1);
+        v26_1 = (versMajor == 26 && versMinor >= 1) || vFuture;
+        v1_21 = vers.startsWith("1.21") || v26_1;
         v1_20 = vers.startsWith("1.20") || v1_21;
         v1_19 = vers.startsWith("1.19") || v1_20;
         v1_18 = vers.startsWith("1.18") || v1_19;
@@ -206,10 +217,17 @@ public class SentinelVersionCompat {
             SentinelTarget.MOBS = new SentinelTarget(combine(v1_19_passive(), v1_19_monsters()), "MOB");
             SentinelTarget.MONSTERS = new SentinelTarget(v1_19_monsters(), "MONSTER");
         }
-        if (v1_21) { // && !v1_22
+        if (v1_21) { // BREEZE/BOGGED/ARMADILLO added in 1.21, still present in newer versions
             SentinelTarget.HOGLINS = new SentinelTarget(new EntityType[]{EntityType.BREEZE}, "BREEZE");
             SentinelTarget.HOGLINS = new SentinelTarget(new EntityType[]{EntityType.BOGGED}, "BOGGED", "BOGGEDSKELETON", "BOGGED_SKELETON");
             SentinelTarget.HOGLINS = new SentinelTarget(new EntityType[]{EntityType.ARMADILLO}, "ARMADILLO");
+        }
+        if (v1_21 && !v26_1) {
+            SentinelTarget.PASSIVE_MOBS = new SentinelTarget(v1_19_passive(), passiveNames());
+            SentinelTarget.MOBS = new SentinelTarget(combine(v1_19_passive(), v1_19_monsters()), "MOB");
+            SentinelTarget.MONSTERS = new SentinelTarget(v1_19_monsters(), "MONSTER");
+        }
+        if (v26_1) { // && !future ; 26.1 "Tiny Takeover" added no new mobs (only baby variants of existing mobs), so reuse the latest known lists
             SentinelTarget.PASSIVE_MOBS = new SentinelTarget(v1_19_passive(), passiveNames());
             SentinelTarget.MOBS = new SentinelTarget(combine(v1_19_passive(), v1_19_monsters()), "MOB");
             SentinelTarget.MONSTERS = new SentinelTarget(v1_19_monsters(), "MONSTER");


### PR DESCRIPTION
Adds compatibility with Minecraft 26.1.

Tested against Paper `26.1.2 build 70` with Citizens `2.0.42 b4198`.

Fixes #418 